### PR TITLE
v1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: swift
 os: osx
-osx_image: xcode10.2
+osx_image: xcode11
 script: xcodebuild -project YMKit.xcodeproj -scheme YMKit -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
-xcode_destination: platform=iOS Simulator,OS=12.2,name=iPhone XS Max
+xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone XS Max
 xcode_scheme: YMKit
-xcode_sdk: iphonesimulator12.2
+xcode_sdk: iphonesimulator13.0
 xcode_workspace: YMKit.xcodeproj

--- a/YMKit.podspec
+++ b/YMKit.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |spec|
 
   spec.name = "YMKit"
-  spec.version = "1.0"
+  spec.version = "1.1"
   spec.summary = "YMKit is a collection of tools for quicker and easier development of iOS apps."
-  spec.homepage = "https://ym.dev/kit"
+  spec.homepage = "https://kit.ym.dev/"
   spec.license = "Apache License, version 2"
   spec.author = "Yakov Manshin"
   spec.social_media_url = "https://twitter.com/yakovmanshin"

--- a/YMKit.xcodeproj/project.pbxproj
+++ b/YMKit.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 		666E78282274B9AC00CFF08A /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		667A17CA22B15AA40010CF86 /* YMStringRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMStringRepresentable.swift; sourceTree = "<group>"; };
 		667F2F8922A291E90079B342 /* YMJSONDataCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMJSONDataCodable.swift; sourceTree = "<group>"; };
-		668A8D1F22EEC29700CE26E5 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
+		668A8D1F22EEC29700CE26E5 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
 		66A265F9229ABBA7009C2DE7 /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		66A265FB229ABE63009C2DE7 /* YMErrorStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMErrorStringConvertible.swift; sourceTree = "<group>"; };
 		66B22B2E22C79FFC00AB7CFF /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
@@ -305,6 +305,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 101;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/YMKit.xcodeproj/project.pbxproj
+++ b/YMKit.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ym.kit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/YMKit.xcodeproj/project.pbxproj
+++ b/YMKit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		666E78292274B9AC00CFF08A /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E78282274B9AC00CFF08A /* UIView+Extensions.swift */; };
 		667A17CB22B15AA40010CF86 /* YMStringRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667A17CA22B15AA40010CF86 /* YMStringRepresentable.swift */; };
 		667F2F8A22A291E90079B342 /* YMJSONDataCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667F2F8922A291E90079B342 /* YMJSONDataCodable.swift */; };
+		668A8D2022EEC29700CE26E5 /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668A8D1F22EEC29700CE26E5 /* UITableView+Extensions.swift */; };
 		66A265FA229ABBA7009C2DE7 /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A265F9229ABBA7009C2DE7 /* UIImageView+Extensions.swift */; };
 		66A265FC229ABE63009C2DE7 /* YMErrorStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A265FB229ABE63009C2DE7 /* YMErrorStringConvertible.swift */; };
 		66B22B2F22C79FFC00AB7CFF /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B22B2E22C79FFC00AB7CFF /* Data+Extensions.swift */; };
@@ -36,6 +37,7 @@
 		666E78282274B9AC00CFF08A /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		667A17CA22B15AA40010CF86 /* YMStringRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMStringRepresentable.swift; sourceTree = "<group>"; };
 		667F2F8922A291E90079B342 /* YMJSONDataCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMJSONDataCodable.swift; sourceTree = "<group>"; };
+		668A8D1F22EEC29700CE26E5 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
 		66A265F9229ABBA7009C2DE7 /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		66A265FB229ABE63009C2DE7 /* YMErrorStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMErrorStringConvertible.swift; sourceTree = "<group>"; };
 		66B22B2E22C79FFC00AB7CFF /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				66B6400421EA7D52005DA4B0 /* String+Extensions.swift */,
 				66B6400621EA7D52005DA4B0 /* UIColor+Extensions.swift */,
 				66A265F9229ABBA7009C2DE7 /* UIImageView+Extensions.swift */,
+				668A8D1F22EEC29700CE26E5 /* UITableView+Extensions.swift */,
 				66B6400721EA7D53005DA4B0 /* UIViewController+Extensions.swift */,
 				666E78282274B9AC00CFF08A /* UIView+Extensions.swift */,
 			);
@@ -222,6 +225,7 @@
 				66B22B2F22C79FFC00AB7CFF /* Data+Extensions.swift in Sources */,
 				66B6400921EA7D53005DA4B0 /* String+Extensions.swift in Sources */,
 				660F4CC2222EE919007C4C4C /* YMKit.swift in Sources */,
+				668A8D2022EEC29700CE26E5 /* UITableView+Extensions.swift in Sources */,
 				66B6400C21EA7D53005DA4B0 /* UIViewController+Extensions.swift in Sources */,
 				66A265FA229ABBA7009C2DE7 /* UIImageView+Extensions.swift in Sources */,
 				66600ED921ECB29000236A30 /* Int+Extensions.swift in Sources */,

--- a/YMKit/Extensions/String+Extensions.swift
+++ b/YMKit/Extensions/String+Extensions.swift
@@ -65,3 +65,35 @@ extension String {
     }
     
 }
+
+// MARK: - MATCHING AGAINST REGULAR EXPRESSIONS
+
+extension String {
+    
+    /// Indicates whether the string fully matches (i.e. has exactly one match with) the specified regular expression.
+    ///
+    /// - Parameter regularExpression: *Required.* Regular expression to match the string against.
+    ///
+    /// - Returns: `Bool`. Matching result.
+    @inlinable
+    public func matchesRegularExpression(_ regularExpression: NSRegularExpression) -> Bool {
+        return regularExpression.numberOfMatches(in: self, options: [], range: NSRange(location: 0, length: self.count)) == 1
+    }
+    
+    /// Indicates whether the string fully matches (i.e. has exactly one match with) a regular expression initialized with the specified pattern with options.
+    ///
+    /// - Parameter regularExpressionPattern: *Required.* Regular expression pattern to initialize an `NSRegularExpression` from..
+    /// - Parameter options: *Optional.* `NSRegularExpression.Options` to use when initializing an `NSRegularExpression`; default is `[]`.
+    ///
+    /// - Returns: `Bool?`. Matching result, if regular expression initialized successfully; otherwise, `nil`.
+    public func matchesRegularExpression(fromPattern regularExpressionPattern: String, withOptions options: NSRegularExpression.Options = []) -> Bool? {
+        do {
+            let regularExpression = try NSRegularExpression(pattern: regularExpressionPattern, options: options)
+            
+            return self.matchesRegularExpression(regularExpression)
+        } catch {
+            return nil
+        }
+    }
+    
+}

--- a/YMKit/Extensions/UITableView+Extensions.swift
+++ b/YMKit/Extensions/UITableView+Extensions.swift
@@ -1,0 +1,36 @@
+//
+//  UITableView+Extensions.swift
+//  YMKit
+//
+//  Created by Yakov Manshin on 7/29/19.
+//  Copyright © 2019 Yakov Manshin. All rights reserved.
+//
+
+import UIKit
+
+extension UITableView {
+    
+    private func adjustHeight(of view: UIView) {
+        let targetSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        
+        guard view.frame.size.height != targetSize.height else { return }
+        
+        view.frame.size.height = targetSize.height
+        
+        // iOS 9 only
+        self.layoutIfNeeded()
+    }
+    
+    public func adjustHeaderViewHeight() {
+        guard let headerView = self.tableHeaderView else { return }
+        
+        adjustHeight(of: headerView)
+    }
+    
+    public func adjustFooterViewHeight() {
+        guard let footerView = self.tableFooterView else { return }
+        
+        adjustHeight(of: footerView)
+    }
+    
+}

--- a/YMKit/Extensions/UITableView+Extensions.swift
+++ b/YMKit/Extensions/UITableView+Extensions.swift
@@ -21,12 +21,14 @@ extension UITableView {
         self.layoutIfNeeded()
     }
     
+    /// Automatically adjusts height of the header view to fit the content.
     public func adjustHeaderViewHeight() {
         guard let headerView = self.tableHeaderView else { return }
         
         adjustHeight(of: headerView)
     }
     
+    /// Automatically adjusts height of the footer view to fit the content.
     public func adjustFooterViewHeight() {
         guard let footerView = self.tableFooterView else { return }
         

--- a/YMKit/Extensions/UIViewController+Extensions.swift
+++ b/YMKit/Extensions/UIViewController+Extensions.swift
@@ -75,3 +75,46 @@ extension UIViewController {
     }
     
 }
+
+// MARK: - LOCALIZED ALERTS
+
+extension UIViewController {
+    
+    /// Displays an alert with one or two options with localized title, message, and option label keys.
+    ///
+    /// + If `primaryOptionLabelKey` or `primaryOptionAction` is not set, the alert will have only one (cancel) option.
+    ///
+    /// - Parameter titleKey: *Required.* Localization key for the title of the alert.
+    /// - Parameter messageKey: *Optional.* Localization key for the message of the alert; default is `nil`.
+    /// - Parameter cancelOptionLabelKey: *Optional.* Localization key for the cancel option label; default is OK (literally).
+    /// - Parameter cancelOptionAction: *Optional.* Closure to execute when the cancel option is selected; default is `nil`.
+    /// - Parameter primaryOptionLabelKey: *Optional.* Localization key for the primary option label; default is `nil`.
+    /// - Parameter primaryOptionStyle: *Optional.* See `UIAlertAction.Style`; default is `default`.
+    /// - Parameter primaryOptionAction: *Optional.* Closure to execute when the primary option is selected; default is `nil`.
+    public func displayLocalizedAlert(titled titleKey: String, saying messageKey: String? = nil, cancelOptionLabel cancelOptionLabelKey: String = "OK", cancelOptionAction: ((UIAlertAction) -> Void)? = nil, primaryOptionLabel primaryOptionLabelKey: String? = nil, primaryOptionStyle: UIAlertAction.Style = .default, primaryOptionAction: ((UIAlertAction) -> Void)? = nil) {
+        let title = titleKey.localized
+        let message = messageKey?.localized
+        let primaryOptionLabel = primaryOptionLabelKey?.localized
+        
+        let cancelOptionLabel: String
+        if cancelOptionLabelKey == "OK" {
+            cancelOptionLabel = "OK"
+        } else {
+            cancelOptionLabel = cancelOptionLabelKey.localized
+        }
+        
+        displayAlert(titled: title, saying: message, cancelOptionLabel: cancelOptionLabel, cancelOptionAction: cancelOptionAction, primaryOptionLabel: primaryOptionLabel, primaryOptionStyle: primaryOptionStyle, primaryOptionAction: primaryOptionAction)
+    }
+    
+    /// Displays an info alert with a single (OK) button with localized title and message.
+    /// - Parameter titleKey: *Required.* Localization key for the title of the alert.
+    /// - Parameter messageKey: *Optional.* Localization key for the message of the alert; default is `nil`.
+    /// - Parameter postAlertAction: *Optional.* Closure to execute when the alert is dismissed; default is `nil`.
+    public func displayLocalizedInfoAlert(titled titleKey: String, saying messageKey: String? = nil, triggering postAlertAction: ((UIAlertAction) -> Void)? = nil) {
+        let title = titleKey.localized
+        let message = messageKey?.localized
+        
+        displayInfoAlert(titled: title, saying: message, triggering: postAlertAction)
+    }
+    
+}

--- a/YMKit/Extensions/UIViewController+Extensions.swift
+++ b/YMKit/Extensions/UIViewController+Extensions.swift
@@ -37,18 +37,17 @@ extension UIViewController {
 
 extension UIViewController {
     
-    /**
-     Display an alert with the specified title, message, and up to two options.
-     + The primary option is displayed only when both `primaryOptionLabel` and `primaryOptionAction` are set.
-     - Parameters:
-        - title: Title of the alert
-        - message: Message of the alert; default is `nil`
-        - cancelOptionLabel: Label of the cancel option; default is “OK”
-        - cancelOptionAction: Block of code to execute when the cancel option is seleected; default is `void`
-        - primaryOptionLabel: Label of the primary option; default is `nil`
-        - primaryOptionStyle: See `UIAlertAction.Style`; default is `default`
-        - primaryOptionAction: Block of code to execute when the primary option is seleected; default is `void`
-    */
+    /// Displays an alert with one or two options.
+    ///
+    /// + If `primaryOptionLabelKey` or `primaryOptionAction` is not set, the alert will have only one (cancel) option.
+    ///
+    /// - Parameter title: *Required.* Title of the alert.
+    /// - Parameter message: *Optional.* Message of the alert; default is `nil`.
+    /// - Parameter cancelOptionLabel: *Optional.* Cancel option label; default is OK.
+    /// - Parameter cancelOptionAction: *Optional.* Closure to execute when the cancel option is selected; default is `nil`.
+    /// - Parameter primaryOptionLabel: *Optional.* Primary option label; default is `nil`.
+    /// - Parameter primaryOptionStyle: *Optional.* See `UIAlertAction.Style`; default is `default`.
+    /// - Parameter primaryOptionAction: *Optional.* Closure to execute when the primary option is selected; default is `nil`.
     public func displayAlert(titled title: String, saying message: String? = nil, cancelOptionLabel: String = "OK", cancelOptionAction: ((UIAlertAction) -> Void)? = nil, primaryOptionLabel: String? = nil, primaryOptionStyle: UIAlertAction.Style = .default, primaryOptionAction: ((UIAlertAction) -> Void)? = nil) {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
@@ -63,13 +62,10 @@ extension UIViewController {
         present(alertController, animated: true, completion: nil)
     }
     
-    /**
-     Display an info alert with the specified title, message, and the OK button.
-     - Parameters:
-        - title: Title of the alert
-        - message: Message of the alert
-        - postAlertAction: Block of code to execute when the alert is dismissed; not required
-     */
+    /// Displays an info alert with a single (OK) button.
+    /// - Parameter titleKey: *Required.* Localization key for the title of the alert.
+    /// - Parameter messageKey: *Optional.* Localization key for the message of the alert; default is `nil`.
+    /// - Parameter postAlertAction: *Optional.* Closure to execute when the alert is dismissed; default is `nil`.
     public func displayInfoAlert(titled title: String, saying message: String? = nil, triggering postAlertAction: ((UIAlertAction) -> Void)? = nil) {
         displayAlert(titled: title, saying: message, cancelOptionAction: postAlertAction)
     }


### PR DESCRIPTION
* Introduced two new `UIViewController` methods, `displayLocalizedAlert(titled:saying:cancelOptionLabel:cancelOptionAction:primaryOptionLabel:primaryOptionStyle:primaryOptionAction:)` and `displayLocalizedInfoAlert(titled:saying:triggering:)`, for displaying alerts with automatically localized labels
* Added two new `String` methods, `matchesRegularExpression(_:)` and `matchesRegularExpression(fromPattern:withOptions:)`, for matching strings against regular expressions
* Added `UITableView` extensions for adjusting its header’s and footer’s height
* Documentation updates
* Updated Travis CI configuration to run checks with Xcode 11 and iOS 13